### PR TITLE
Add expandable NPC and action menus

### DIFF
--- a/game.js
+++ b/game.js
@@ -2,6 +2,8 @@ const locationNameEl = document.getElementById('location-name');
 const locationDescEl = document.getElementById('location-description');
 const npcListEl = document.getElementById('npc-list');
 const actionListEl = document.getElementById('action-list');
+const npcSectionEl = document.getElementById('npcs');
+const actionSectionEl = document.getElementById('actions');
 const statusInfoEl = document.getElementById('status-info');
 
 const player = {
@@ -37,6 +39,10 @@ function render() {
   statusInfoEl.textContent = `HP: ${player.hp}  기력: ${player.stamina}`;
 }
 
+function toggleSection(sectionEl) {
+  sectionEl.classList.toggle('active');
+}
+
 async function loadData() {
   const [actionData, locationData] = await Promise.all([
     fetch('data/actions.json').then(res => res.json()),
@@ -50,4 +56,15 @@ async function loadData() {
 }
 
 loadData();
+
+npcSectionEl.querySelector('h3').addEventListener('click', () => toggleSection(npcSectionEl));
+actionSectionEl.querySelector('h3').addEventListener('click', () => toggleSection(actionSectionEl));
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === '1') {
+    toggleSection(npcSectionEl);
+  } else if (e.key === '2') {
+    toggleSection(actionSectionEl);
+  }
+});
 

--- a/index.html
+++ b/index.html
@@ -11,12 +11,12 @@
       <h2 id="location-name"></h2>
       <p id="location-description"></p>
     </div>
-    <div id="npcs">
-      <h3>NPC</h3>
+    <div id="npcs" class="menu">
+      <h3>1. NPC</h3>
       <ul id="npc-list"></ul>
     </div>
-    <div id="actions">
-      <h3>Actions</h3>
+    <div id="actions" class="menu">
+      <h3>2. Actions</h3>
       <ul id="action-list"></ul>
     </div>
     <div id="status">

--- a/style.css
+++ b/style.css
@@ -17,10 +17,27 @@ body {
   box-shadow: 0 0 10px rgba(0,0,0,0.5);
 }
 
-#npc-list,
-#action-list {
+
+.menu {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 10px;
+}
+
+.menu h3 {
+  margin: 0;
+  cursor: pointer;
+}
+
+.menu ul {
   list-style: none;
   padding-left: 0;
+  margin: 0 0 0 10px;
+  display: none;
+}
+
+.menu.active ul {
+  display: block;
 }
 
 #status {


### PR DESCRIPTION
## Summary
- Toggle NPC and Actions menus by clicking headings or pressing number keys, revealing items to the right.
- Implement flex-based menu styling for side-by-side headings and lists.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de07115e8832abd48498b321793d8