### PR TITLE
Add inventory UI with equipment and category tabs

### DIFF
--- a/game.js
+++ b/game.js
@@ -6,6 +6,18 @@ const npcSectionEl = document.getElementById('npcs');
 const actionSectionEl = document.getElementById('actions');
 const npcHeaderEl = document.getElementById('npc-header');
 const actionHeaderEl = document.getElementById('action-header');
+const inventoryHeaderEl = document.getElementById('inventory-header');
+const inventoryMenuEl = document.getElementById('inventory-menu');
+const inventoryUIEl = document.getElementById('inventory-ui');
+const inventoryTabsEl = document.getElementById('inventory-tabs');
+const inventoryItemsEl = document.getElementById('inventory-items');
+const equipHeadEl = document.getElementById('equip-head');
+const equipTopEl = document.getElementById('equip-top');
+const equipBottomEl = document.getElementById('equip-bottom');
+const equipBackEl = document.getElementById('equip-back');
+const equipGlovesEl = document.getElementById('equip-gloves');
+const equipShoesEl = document.getElementById('equip-shoes');
+const closeInventoryEl = document.getElementById('close-inventory');
 const statusInfoEl = document.getElementById('status-info');
 const playerCommandEl = document.getElementById('player-command');
 const submitCommandEl = document.getElementById('submit-command');
@@ -19,14 +31,41 @@ let actions = [];
 let locations = {};
 let currentLocation = '';
 let currentMenu = 'main';
+let currentCategory = 'all';
+
+const inventory = [
+  { name: '낡은 칼', type: 'weapon' },
+  { name: '천 갑옷', type: 'armor' },
+  { name: '붕대', type: 'medicine' },
+  { name: '길드 증표', type: 'important' }
+];
+
+const equipment = {
+  head: null,
+  top: null,
+  bottom: null,
+  back: null,
+  gloves: null,
+  shoes: null
+};
+
+const categories = [
+  { key: 'all', label: '전체' },
+  { key: 'weapon', label: '무기' },
+  { key: 'armor', label: '방어구' },
+  { key: 'medicine', label: '의약품' },
+  { key: 'important', label: '중요 물품' }
+];
 
 function updateHeaders() {
   if (currentMenu === 'main') {
     npcHeaderEl.textContent = '1. 인물';
     actionHeaderEl.textContent = '2. 행동';
+    inventoryHeaderEl.textContent = '3. 소지품';
   } else {
     npcHeaderEl.textContent = '인물';
     actionHeaderEl.textContent = '행동';
+    inventoryHeaderEl.textContent = '소지품';
   }
 }
 
@@ -67,6 +106,13 @@ function showMainMenu() {
   actionListEl.innerHTML = '';
   npcSectionEl.classList.remove('active');
   actionSectionEl.classList.remove('active');
+  inventoryMenuEl.style.display = '';
+  inventoryUIEl.style.display = 'none';
+  document.getElementById('location').style.display = '';
+  npcSectionEl.style.display = '';
+  actionSectionEl.style.display = '';
+  document.getElementById('status').style.display = '';
+  document.getElementById('player-input-container').style.display = '';
 }
 
 function openNpcMenu() {
@@ -89,6 +135,61 @@ function openActionMenu() {
   displayMenu(actionListEl, items);
   actionSectionEl.classList.add('active');
   npcSectionEl.classList.remove('active');
+}
+
+function renderInventory() {
+  renderEquipment();
+  renderInventoryTabs();
+  renderInventoryItems();
+}
+
+function renderInventoryTabs() {
+  inventoryTabsEl.innerHTML = '';
+  categories.forEach(cat => {
+    const btn = document.createElement('button');
+    btn.textContent = cat.label;
+    btn.addEventListener('click', () => {
+      currentCategory = cat.key;
+      renderInventoryItems();
+    });
+    inventoryTabsEl.appendChild(btn);
+  });
+}
+
+function renderInventoryItems() {
+  inventoryItemsEl.innerHTML = '';
+  const filtered = inventory.filter(item => currentCategory === 'all' || item.type === currentCategory);
+  filtered.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = item.name;
+    inventoryItemsEl.appendChild(li);
+  });
+}
+
+function renderEquipment() {
+  equipHeadEl.textContent = equipment.head || '없음';
+  equipTopEl.textContent = equipment.top || '없음';
+  equipBottomEl.textContent = equipment.bottom || '없음';
+  equipBackEl.textContent = equipment.back || '없음';
+  equipGlovesEl.textContent = equipment.gloves || '없음';
+  equipShoesEl.textContent = equipment.shoes || '없음';
+}
+
+function openInventory() {
+  currentMenu = 'inventory';
+  updateHeaders();
+  document.getElementById('location').style.display = 'none';
+  npcSectionEl.style.display = 'none';
+  actionSectionEl.style.display = 'none';
+  document.getElementById('status').style.display = 'none';
+  document.getElementById('player-input-container').style.display = 'none';
+  inventoryMenuEl.style.display = 'none';
+  inventoryUIEl.style.display = 'block';
+  renderInventory();
+}
+
+function closeInventory() {
+  showMainMenu();
 }
 
 async function loadData() {
@@ -136,6 +237,8 @@ function handleCommand() {
       openNpcMenu();
     } else if (num === 2) {
       openActionMenu();
+    } else if (num === 3) {
+      openInventory();
     }
   } else if (currentMenu === 'npcs') {
     const loc = locations[currentLocation];
@@ -164,4 +267,7 @@ playerCommandEl.addEventListener('keypress', (e) => {
     handleCommand();
   }
 });
+
+inventoryHeaderEl.addEventListener('click', openInventory);
+closeInventoryEl.addEventListener('click', closeInventory);
 

--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
       <h3 id="action-header"></h3>
       <ul id="action-list"></ul>
     </div>
+    <div id="inventory-menu" class="menu">
+      <h3 id="inventory-header"></h3>
+    </div>
     <div id="status">
       <h3>Status</h3>
       <p id="status-info"></p>
@@ -26,6 +29,26 @@
     <div id="player-input-container">
       <input type="text" id="player-command" placeholder="명령을 입력하세요" />
       <button id="submit-command">입력</button>
+    </div>
+    <div id="inventory-ui">
+      <div id="inventory-container">
+        <div id="inventory-left">
+          <div id="inventory-tabs"></div>
+          <ul id="inventory-items"></ul>
+        </div>
+        <div id="equipment-right">
+          <h3>장착</h3>
+          <ul>
+            <li>머리: <span id="equip-head">없음</span></li>
+            <li>상의: <span id="equip-top">없음</span></li>
+            <li>하의: <span id="equip-bottom">없음</span></li>
+            <li>등: <span id="equip-back">없음</span></li>
+            <li>장갑: <span id="equip-gloves">없음</span></li>
+            <li>신발: <span id="equip-shoes">없음</span></li>
+          </ul>
+          <button id="close-inventory">뒤로</button>
+        </div>
+      </div>
     </div>
   </div>
   <script src="game.js"></script>

--- a/style.css
+++ b/style.css
@@ -61,3 +61,58 @@ body {
 #player-input-container button {
   cursor: pointer;
 }
+
+#inventory-menu {
+  cursor: pointer;
+}
+
+#inventory-ui {
+  display: none;
+  margin-top: 20px;
+}
+
+#inventory-container {
+  display: flex;
+}
+
+#inventory-left {
+  flex: 1;
+}
+
+#inventory-tabs {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+#inventory-tabs button {
+  background-color: #000;
+  color: #00ff00;
+  border: 1px solid #00ff00;
+  font-family: 'Courier New', monospace;
+  cursor: pointer;
+}
+
+#inventory-items {
+  list-style: none;
+  padding-left: 0;
+}
+
+#equipment-right {
+  flex: 1;
+  padding-left: 20px;
+}
+
+#equipment-right ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+#close-inventory {
+  margin-top: 20px;
+  background-color: #000;
+  color: #00ff00;
+  border: 1px solid #00ff00;
+  font-family: 'Courier New', monospace;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add `소지품` entry to main menu and open dedicated inventory screen
- display equipped gear and categorize items with simple tabs

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_689df4045ce0832ab566ee80d179745d