### PR TITLE
feat: highlight selections and improve menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <div id="npcs" class="menu">
       <h3 id="npc-header"></h3>
       <ul id="npc-list"></ul>
+      <ul id="npc-interaction-list" style="display:none;"></ul>
     </div>
     <div id="actions" class="menu">
       <h3 id="action-header"></h3>

--- a/style.css
+++ b/style.css
@@ -40,6 +40,15 @@ body {
   display: block;
 }
 
+.menu li.selected,
+.menu h3.selected {
+  color: #ffff00;
+}
+
+#npc-interaction-list {
+  display: none;
+}
+
 #status {
   margin-top: 20px;
 }


### PR DESCRIPTION
## Summary
- Highlight selected menu items and keep NPC list while showing interactions beside it
- Allow nested menu selections with side-by-side lists
- Show armor slot when prompting to equip items

## Testing
- `node --check game.js`
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e680f5c38832a92f79fd11a47dcc8