### PR TITLE
Expand action menu with rightward submenus

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,9 @@
     </div>
     <div id="actions" class="menu">
       <h3 id="action-header"></h3>
-      <ul id="action-list"></ul>
+      <div id="action-menus">
+        <ul id="action-list"></ul>
+      </div>
     </div>
     <div id="inventory-menu" class="menu">
       <h3 id="inventory-header"></h3>

--- a/style.css
+++ b/style.css
@@ -36,6 +36,10 @@ body {
   display: none;
 }
 
+#action-menus {
+  display: flex;
+}
+
 .menu.active ul {
   display: block;
 }


### PR DESCRIPTION
## Summary
- replace single action list with a flexible container to allow nested menus
- add stack-based menu handling so selecting "행동 → 메뉴" expands with [상태, 기술, 뒤로] and deeper skills lists

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_689e87e985f4832a80b872d67b4893e9