### PR TITLE
Implement weighted weapon damage system and turn progress bar

### DIFF
--- a/data/inventory.json
+++ b/data/inventory.json
@@ -20,6 +20,7 @@
   ],
   "inventory": [
     "rusty_sword",
+    "old_pistol",
     "cloth_armor",
     "bandage",
     "guild_badge"

--- a/data/items.json
+++ b/data/items.json
@@ -5,7 +5,17 @@
       "type": "weapon",
       "subtype": "melee",
       "properties": {
-        "attack": 5
+        "strWeight": 70,
+        "multiplier": 1,
+        "bonus": 5
+      }
+    },
+    "old_pistol": {
+      "name": "낡은 권총",
+      "type": "weapon",
+      "subtype": "firearm",
+      "properties": {
+        "fixedDamage": 15
       }
     },
     "cloth_armor": {

--- a/index.html
+++ b/index.html
@@ -75,6 +75,12 @@
             </div>
             <span id="player-stamina-text"></span>
           </div>
+          <div class="resource">
+            <span class="resource-label">턴</span>
+            <div class="bar-container">
+              <div id="player-turn-bar" class="bar"></div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -277,6 +277,11 @@ body {
   background-color: #ffff00;
 }
 
+#player-turn-bar {
+  background-color: #ffff00;
+  transition: width 0.1s linear;
+}
+
 .enemy-text {
   color: #ff0000;
 }


### PR DESCRIPTION
## Summary
- compute damage using weapon-specific strength/agility weighting and multipliers
- support fixed-damage firearms and add an example pistol item
- update inventory to include the new firearm
- show a real-time gauge that fills until the player's next turn

## Testing
- `node -c game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a54073dde4832a82dd7b030c17f68d