### PR TITLE
Add equipment-based condition system

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -35,7 +35,9 @@
     },
     "guild_badge": {
       "name": "길드 증표",
-      "type": "important",
+      "type": "armor",
+      "subtype": "back",
+      "conditions": ["guild_access"],
       "properties": {}
     }
   }

--- a/index.html
+++ b/index.html
@@ -134,6 +134,7 @@
         </div>
         <div id="status-right">
           <p id="status-description"></p>
+          <ul id="condition-list"></ul>
           <button id="close-status">뒤로</button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Track character qualifications with a new condition system
- Equip or unequip items to add or remove associated conditions
- Display current conditions in the status screen

## Testing
- `node --check game.js`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('data/items.json','utf8')); console.log('items ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68a562187044832abd51785cd20f5e51