### PR TITLE
Always display NPC list in main UI

### DIFF
--- a/game.js
+++ b/game.js
@@ -317,7 +317,7 @@ function showMainMenu() {
   npcInteractionListEl.innerHTML = '';
   npcInteractionListEl.style.display = 'none';
   npcListEl.querySelectorAll('li').forEach(li => li.classList.remove('selected'));
-  npcSectionEl.classList.remove('active');
+  npcSectionEl.classList.add('active');
   actionSectionEl.classList.remove('active');
   inventoryMenuEl.style.display = '';
   inventoryUIEl.style.display = 'none';
@@ -721,7 +721,14 @@ function openNpcInteractions(npc, npcIndex) {
 
 function openActionMenu() {
   currentMenu = 'actions';
+  currentNpc = '';
   updateHeaders();
+  // Ensure NPC list remains visible but non-interactive
+  renderNpcList();
+  npcInteractionListEl.innerHTML = '';
+  npcInteractionListEl.style.display = 'none';
+  npcListEl.querySelectorAll('li').forEach(li => li.classList.remove('selected'));
+
   actionMenusEl.innerHTML = '';
   actionMenuStack = [{ ul: actionListEl, items: [], onSelect: null }];
   actionMenusEl.appendChild(actionListEl);
@@ -734,7 +741,7 @@ function openActionMenu() {
     }
   });
   actionSectionEl.classList.add('active');
-  npcSectionEl.classList.remove('active');
+  npcSectionEl.classList.add('active');
 }
 
 function handleAction(action) {


### PR DESCRIPTION
## Summary
- Keep NPC section active so its list is visible on the main screen
- Opening the Actions menu now resets NPC list to a passive state while keeping it expanded

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c55c4b74832a82a632e3aad4af83