### PR TITLE
Add tree menu with branching lines

### DIFF
--- a/game.js
+++ b/game.js
@@ -1340,3 +1340,33 @@ battleResultCloseEl.addEventListener('click', () => {
   render();
 });
 
+// Tree menu interaction
+const treeItems = document.querySelectorAll('#tree-menu li');
+treeItems.forEach(item => {
+  item.addEventListener('click', function (e) {
+    e.stopPropagation();
+    const all = document.querySelectorAll('#tree-menu li');
+    all.forEach(el => {
+      el.classList.remove('expanded', 'selected');
+      el.style.display = 'none';
+      const child = el.querySelector(':scope > ul');
+      if (child) child.style.display = 'none';
+    });
+    let node = this;
+    while (node && node.matches('#tree-menu li')) {
+      node.style.display = '';
+      node.classList.add('expanded');
+      const child = node.querySelector(':scope > ul');
+      if (child) child.style.display = 'block';
+      node = node.parentElement.closest('li');
+    }
+    const childList = this.querySelector(':scope > ul');
+    if (childList) {
+      childList.querySelectorAll(':scope > li').forEach(li => {
+        li.style.display = '';
+      });
+    }
+    this.classList.add('selected');
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -150,6 +150,21 @@
         </div>
       </div>
     </div>
+    <div id="tree-menu">
+      <ul class="tree">
+        <li>루트
+          <ul>
+            <li>가지 1
+              <ul>
+                <li>잎 1-1</li>
+                <li>잎 1-2</li>
+              </ul>
+            </li>
+            <li>가지 2</li>
+          </ul>
+        </li>
+      </ul>
+    </div>
   </div>
   <div id="flash-overlay"></div>
   <script src="game.js"></script>

--- a/style.css
+++ b/style.css
@@ -301,3 +301,47 @@ body {
 .enemy-bar {
   background-color: #ff0000;
 }
+
+/* Tree menu styling */
+#tree-menu {
+  margin-top: 20px;
+}
+
+.tree,
+.tree ul {
+  list-style: none;
+  margin: 0;
+  padding-left: 20px;
+  position: relative;
+}
+
+.tree li {
+  position: relative;
+  cursor: pointer;
+  padding: 2px 0;
+}
+
+.tree li > ul {
+  display: none;
+  margin-left: 10px;
+  padding-left: 20px;
+  border-left: 1px solid #00ff00;
+}
+
+.tree li.expanded > ul {
+  display: block;
+}
+
+.tree li.expanded > ul > li::before {
+  content: '';
+  position: absolute;
+  top: 10px;
+  left: -20px;
+  width: 20px;
+  height: 0;
+  border-top: 1px solid #00ff00;
+}
+
+.tree li.selected {
+  color: #ffff00;
+}


### PR DESCRIPTION
## Summary
- Add tree-style menu section that reveals subitems like branches
- Style tree menu with right-angled connectors and selection highlight
- Implement JavaScript logic to keep only selected path expanded

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/html_text_game/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a6d7f4603c832a931a600e8325d4b8