### PR TITLE
Animate tree menu with connecting lines and typing

### DIFF
--- a/game.js
+++ b/game.js
@@ -1341,6 +1341,34 @@ battleResultCloseEl.addEventListener('click', () => {
 });
 
 // Tree menu interaction
+function animateTreeChildren(ul) {
+  setTimeout(() => {
+    const items = ul.querySelectorAll(':scope > li');
+    let index = 0;
+    function showNext() {
+      if (index >= items.length) return;
+      const li = items[index];
+      const text = li.textContent;
+      li.textContent = '';
+      li.style.display = '';
+      li.classList.add('show-line');
+      setTimeout(() => {
+        let char = 0;
+        const interval = setInterval(() => {
+          if (char < text.length) {
+            li.textContent += text.charAt(char++);
+          } else {
+            clearInterval(interval);
+            index++;
+            showNext();
+          }
+        }, 50);
+      }, 300);
+    }
+    showNext();
+  }, 300);
+}
+
 const treeItems = document.querySelectorAll('#tree-menu li');
 treeItems.forEach(item => {
   item.addEventListener('click', function (e) {
@@ -1350,7 +1378,10 @@ treeItems.forEach(item => {
       el.classList.remove('expanded', 'selected');
       el.style.display = 'none';
       const child = el.querySelector(':scope > ul');
-      if (child) child.style.display = 'none';
+      if (child) {
+        child.style.display = 'none';
+        child.classList.remove('animating');
+      }
     });
     let node = this;
     while (node && node.matches('#tree-menu li')) {
@@ -1363,8 +1394,11 @@ treeItems.forEach(item => {
     const childList = this.querySelector(':scope > ul');
     if (childList) {
       childList.querySelectorAll(':scope > li').forEach(li => {
-        li.style.display = '';
+        li.style.display = 'none';
+        li.classList.remove('show-line');
       });
+      childList.classList.add('animating');
+      animateTreeChildren(childList);
     }
     this.classList.add('selected');
   });

--- a/style.css
+++ b/style.css
@@ -325,21 +325,53 @@ body {
   display: none;
   margin-left: 10px;
   padding-left: 20px;
-  border-left: 1px solid #00ff00;
+  position: relative;
+  overflow: hidden;
 }
 
 .tree li.expanded > ul {
   display: block;
 }
 
-.tree li.expanded > ul > li::before {
+.tree li > ul::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 0;
+  background-color: #00ff00;
+}
+
+.tree li.expanded > ul::before {
+  height: 100%;
+}
+
+.tree li > ul.animating::before {
+  animation: drawVertical 0.3s forwards;
+}
+
+.tree li > ul > li {
+  position: relative;
+}
+
+.tree li > ul > li::before {
   content: '';
   position: absolute;
   top: 10px;
   left: -20px;
-  width: 20px;
-  height: 0;
+  width: 0;
   border-top: 1px solid #00ff00;
+  transition: width 0.3s;
+}
+
+.tree li > ul > li.show-line::before {
+  width: 20px;
+}
+
+@keyframes drawVertical {
+  from { height: 0; }
+  to { height: 100%; }
 }
 
 .tree li.selected {


### PR DESCRIPTION
## Summary
- Animate tree-menu branch lines growing into child nodes
- Sequentially type each child item after the line extends

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7346037a8832a9677a92708f292c2