### PR TITLE
Add line animation to menus and remove unused tree block

### DIFF
--- a/game.js
+++ b/game.js
@@ -287,8 +287,11 @@ function highlightItem(listEl, index) {
 
 function displayMenu(listEl, items, onSelect) {
   listEl.innerHTML = '';
-  const elements = items.map((text, idx) => {
+  listEl.classList.add('menu-tree');
+  listEl.classList.remove('animating');
+  items.forEach((text, idx) => {
     const li = document.createElement('li');
+    li.dataset.fullText = `${idx + 1}. ${text}`;
     li.textContent = '';
     if (onSelect) {
       li.addEventListener('click', () => {
@@ -297,21 +300,35 @@ function displayMenu(listEl, items, onSelect) {
       });
     }
     listEl.appendChild(li);
-    return { li, fullText: `${idx + 1}. ${text}` };
   });
+  animateMenuList(listEl);
+}
 
-  let step = 0;
-  const interval = setInterval(() => {
-    let done = true;
-    elements.forEach(el => {
-      if (step < el.fullText.length) {
-        el.li.textContent = el.fullText.slice(0, step + 1);
-        if (step < el.fullText.length - 1) done = false;
+function animateMenuList(listEl) {
+  listEl.classList.add('animating');
+  const items = listEl.querySelectorAll(':scope > li');
+  let index = 0;
+  function showNext() {
+    if (index >= items.length) {
+      listEl.classList.remove('animating');
+      return;
+    }
+    const li = items[index];
+    const text = li.dataset.fullText || '';
+    li.style.display = '';
+    li.classList.add('show-line');
+    let char = 0;
+    const interval = setInterval(() => {
+      if (char < text.length) {
+        li.textContent += text.charAt(char++);
+      } else {
+        clearInterval(interval);
+        index++;
+        showNext();
       }
-    });
-    step++;
-    if (done) clearInterval(interval);
-  }, 50);
+    }, 50);
+  }
+  setTimeout(showNext, 300);
 }
 
 function setActionMenu(level, items, onSelect) {
@@ -1353,69 +1370,5 @@ battleResultCloseEl.addEventListener('click', () => {
   battleResultEl.style.display = 'none';
   showMainMenu();
   render();
-});
-
-// Tree menu interaction
-function animateTreeChildren(ul) {
-  setTimeout(() => {
-    const items = ul.querySelectorAll(':scope > li');
-    let index = 0;
-    function showNext() {
-      if (index >= items.length) return;
-      const li = items[index];
-      const text = li.textContent;
-      li.textContent = '';
-      li.style.display = '';
-      li.classList.add('show-line');
-      setTimeout(() => {
-        let char = 0;
-        const interval = setInterval(() => {
-          if (char < text.length) {
-            li.textContent += text.charAt(char++);
-          } else {
-            clearInterval(interval);
-            index++;
-            showNext();
-          }
-        }, 50);
-      }, 300);
-    }
-    showNext();
-  }, 300);
-}
-
-const treeItems = document.querySelectorAll('#tree-menu li');
-treeItems.forEach(item => {
-  item.addEventListener('click', function (e) {
-    e.stopPropagation();
-    const all = document.querySelectorAll('#tree-menu li');
-    all.forEach(el => {
-      el.classList.remove('expanded', 'selected');
-      el.style.display = 'none';
-      const child = el.querySelector(':scope > ul');
-      if (child) {
-        child.style.display = 'none';
-        child.classList.remove('animating');
-      }
-    });
-    let node = this;
-    while (node && node.matches('#tree-menu li')) {
-      node.style.display = '';
-      node.classList.add('expanded');
-      const child = node.querySelector(':scope > ul');
-      if (child) child.style.display = 'block';
-      node = node.parentElement.closest('li');
-    }
-    const childList = this.querySelector(':scope > ul');
-    if (childList) {
-      childList.querySelectorAll(':scope > li').forEach(li => {
-        li.style.display = 'none';
-        li.classList.remove('show-line');
-      });
-      childList.classList.add('animating');
-      animateTreeChildren(childList);
-    }
-    this.classList.add('selected');
-  });
 });
 

--- a/index.html
+++ b/index.html
@@ -150,21 +150,6 @@
         </div>
       </div>
     </div>
-    <div id="tree-menu">
-      <ul class="tree">
-        <li>루트
-          <ul>
-            <li>가지 1
-              <ul>
-                <li>잎 1-1</li>
-                <li>잎 1-2</li>
-              </ul>
-            </li>
-            <li>가지 2</li>
-          </ul>
-        </li>
-      </ul>
-    </div>
   </div>
   <div id="flash-overlay"></div>
   <script src="game.js"></script>

--- a/style.css
+++ b/style.css
@@ -302,38 +302,15 @@ body {
   background-color: #ff0000;
 }
 
-/* Tree menu styling */
-#tree-menu {
-  margin-top: 20px;
-}
-
-.tree,
-.tree ul {
+/* Menu line animation */
+.menu-tree {
   list-style: none;
   margin: 0;
   padding-left: 20px;
   position: relative;
 }
 
-.tree li {
-  position: relative;
-  cursor: pointer;
-  padding: 2px 0;
-}
-
-.tree li > ul {
-  display: none;
-  margin-left: 10px;
-  padding-left: 20px;
-  position: relative;
-  overflow: hidden;
-}
-
-.tree li.expanded > ul {
-  display: block;
-}
-
-.tree li > ul::before {
+.menu-tree::before {
   content: '';
   position: absolute;
   top: 0;
@@ -343,19 +320,18 @@ body {
   background-color: #00ff00;
 }
 
-.tree li.expanded > ul::before {
-  height: 100%;
-}
-
-.tree li > ul.animating::before {
+.menu-tree.animating::before {
   animation: drawVertical 0.3s forwards;
 }
 
-.tree li > ul > li {
+.menu-tree li {
   position: relative;
+  cursor: pointer;
+  padding: 2px 0;
+  display: none;
 }
 
-.tree li > ul > li::before {
+.menu-tree li::before {
   content: '';
   position: absolute;
   top: 10px;
@@ -365,7 +341,7 @@ body {
   transition: width 0.3s;
 }
 
-.tree li > ul > li.show-line::before {
+.menu-tree li.show-line::before {
   width: 20px;
 }
 
@@ -374,6 +350,6 @@ body {
   to { height: 100%; }
 }
 
-.tree li.selected {
+.menu-tree li.selected {
   color: #ffff00;
 }


### PR DESCRIPTION
## Summary
- Animate menu expansion with connecting lines and sequential text display
- Remove unused tree menu example and associated code

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a740c29768832abe34046b3c0a20ae