### PR TITLE
Add line animations to submenu lists and remove demo tree

### DIFF
--- a/game.js
+++ b/game.js
@@ -312,6 +312,20 @@ function displayMenu(listEl, items, onSelect) {
     step++;
     if (done) clearInterval(interval);
   }, 50);
+
+  setTimeout(() => animateListAppearance(listEl), 0);
+}
+
+function animateListAppearance(listEl) {
+  listEl.classList.add('tree-list');
+  listEl.classList.remove('animating');
+  void listEl.offsetWidth;
+  listEl.classList.add('animating');
+  const items = listEl.querySelectorAll(':scope > li');
+  items.forEach(li => li.classList.remove('show-line'));
+  setTimeout(() => {
+    items.forEach(li => li.classList.add('show-line'));
+  }, 300);
 }
 
 function setActionMenu(level, items, onSelect) {
@@ -1353,69 +1367,5 @@ battleResultCloseEl.addEventListener('click', () => {
   battleResultEl.style.display = 'none';
   showMainMenu();
   render();
-});
-
-// Tree menu interaction
-function animateTreeChildren(ul) {
-  setTimeout(() => {
-    const items = ul.querySelectorAll(':scope > li');
-    let index = 0;
-    function showNext() {
-      if (index >= items.length) return;
-      const li = items[index];
-      const text = li.textContent;
-      li.textContent = '';
-      li.style.display = '';
-      li.classList.add('show-line');
-      setTimeout(() => {
-        let char = 0;
-        const interval = setInterval(() => {
-          if (char < text.length) {
-            li.textContent += text.charAt(char++);
-          } else {
-            clearInterval(interval);
-            index++;
-            showNext();
-          }
-        }, 50);
-      }, 300);
-    }
-    showNext();
-  }, 300);
-}
-
-const treeItems = document.querySelectorAll('#tree-menu li');
-treeItems.forEach(item => {
-  item.addEventListener('click', function (e) {
-    e.stopPropagation();
-    const all = document.querySelectorAll('#tree-menu li');
-    all.forEach(el => {
-      el.classList.remove('expanded', 'selected');
-      el.style.display = 'none';
-      const child = el.querySelector(':scope > ul');
-      if (child) {
-        child.style.display = 'none';
-        child.classList.remove('animating');
-      }
-    });
-    let node = this;
-    while (node && node.matches('#tree-menu li')) {
-      node.style.display = '';
-      node.classList.add('expanded');
-      const child = node.querySelector(':scope > ul');
-      if (child) child.style.display = 'block';
-      node = node.parentElement.closest('li');
-    }
-    const childList = this.querySelector(':scope > ul');
-    if (childList) {
-      childList.querySelectorAll(':scope > li').forEach(li => {
-        li.style.display = 'none';
-        li.classList.remove('show-line');
-      });
-      childList.classList.add('animating');
-      animateTreeChildren(childList);
-    }
-    this.classList.add('selected');
-  });
 });
 

--- a/index.html
+++ b/index.html
@@ -150,21 +150,6 @@
         </div>
       </div>
     </div>
-    <div id="tree-menu">
-      <ul class="tree">
-        <li>루트
-          <ul>
-            <li>가지 1
-              <ul>
-                <li>잎 1-1</li>
-                <li>잎 1-2</li>
-              </ul>
-            </li>
-            <li>가지 2</li>
-          </ul>
-        </li>
-      </ul>
-    </div>
   </div>
   <div id="flash-overlay"></div>
   <script src="game.js"></script>

--- a/style.css
+++ b/style.css
@@ -302,60 +302,34 @@ body {
   background-color: #ff0000;
 }
 
-/* Tree menu styling */
-#tree-menu {
-  margin-top: 20px;
-}
-
-.tree,
-.tree ul {
+/* Animated submenu lines */
+.tree-list {
   list-style: none;
   margin: 0;
   padding-left: 20px;
   position: relative;
 }
 
-.tree li {
-  position: relative;
-  cursor: pointer;
-  padding: 2px 0;
-}
-
-.tree li > ul {
-  display: none;
-  margin-left: 10px;
-  padding-left: 20px;
-  position: relative;
-  overflow: hidden;
-}
-
-.tree li.expanded > ul {
-  display: block;
-}
-
-.tree li > ul::before {
+.tree-list::before {
   content: '';
   position: absolute;
   top: 0;
-  left: 0;
+  left: -10px;
   width: 1px;
   height: 0;
   background-color: #00ff00;
 }
 
-.tree li.expanded > ul::before {
-  height: 100%;
-}
-
-.tree li > ul.animating::before {
+.tree-list.animating::before {
   animation: drawVertical 0.3s forwards;
 }
 
-.tree li > ul > li {
+.tree-list li {
   position: relative;
+  padding: 2px 0;
 }
 
-.tree li > ul > li::before {
+.tree-list li::before {
   content: '';
   position: absolute;
   top: 10px;
@@ -365,15 +339,11 @@ body {
   transition: width 0.3s;
 }
 
-.tree li > ul > li.show-line::before {
+.tree-list li.show-line::before {
   width: 20px;
 }
 
 @keyframes drawVertical {
   from { height: 0; }
   to { height: 100%; }
-}
-
-.tree li.selected {
-  color: #ffff00;
 }


### PR DESCRIPTION
## Summary
- Remove unused tree menu stub from the interface
- Animate submenu expansions with connecting lines using new CSS and JS helpers

## Testing
- ❌ `npm test` *(package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7437cff80832a98cf668919bee698