### PR TITLE
Apply line animations to menus and remove tree sample

### DIFF
--- a/game.js
+++ b/game.js
@@ -289,7 +289,7 @@ function displayMenu(listEl, items, onSelect) {
   listEl.innerHTML = '';
   const elements = items.map((text, idx) => {
     const li = document.createElement('li');
-    li.textContent = '';
+    li.style.display = 'none';
     if (onSelect) {
       li.addEventListener('click', () => {
         highlightItem(listEl, idx);
@@ -300,18 +300,31 @@ function displayMenu(listEl, items, onSelect) {
     return { li, fullText: `${idx + 1}. ${text}` };
   });
 
-  let step = 0;
-  const interval = setInterval(() => {
-    let done = true;
-    elements.forEach(el => {
-      if (step < el.fullText.length) {
-        el.li.textContent = el.fullText.slice(0, step + 1);
-        if (step < el.fullText.length - 1) done = false;
+  listEl.classList.remove('animating');
+  void listEl.offsetWidth;
+  listEl.classList.add('animating');
+
+  setTimeout(() => {
+    let index = 0;
+    function showNext() {
+      if (index >= elements.length) return;
+      const el = elements[index];
+      el.li.style.display = '';
+      el.li.classList.add('show-line');
+      let char = 0;
+      function typeChar() {
+        if (char < el.fullText.length) {
+          el.li.textContent += el.fullText.charAt(char++);
+          setTimeout(typeChar, 50);
+        } else {
+          index++;
+          showNext();
+        }
       }
-    });
-    step++;
-    if (done) clearInterval(interval);
-  }, 50);
+      typeChar();
+    }
+    showNext();
+  }, 300);
 }
 
 function setActionMenu(level, items, onSelect) {
@@ -1354,68 +1367,3 @@ battleResultCloseEl.addEventListener('click', () => {
   showMainMenu();
   render();
 });
-
-// Tree menu interaction
-function animateTreeChildren(ul) {
-  setTimeout(() => {
-    const items = ul.querySelectorAll(':scope > li');
-    let index = 0;
-    function showNext() {
-      if (index >= items.length) return;
-      const li = items[index];
-      const text = li.textContent;
-      li.textContent = '';
-      li.style.display = '';
-      li.classList.add('show-line');
-      setTimeout(() => {
-        let char = 0;
-        const interval = setInterval(() => {
-          if (char < text.length) {
-            li.textContent += text.charAt(char++);
-          } else {
-            clearInterval(interval);
-            index++;
-            showNext();
-          }
-        }, 50);
-      }, 300);
-    }
-    showNext();
-  }, 300);
-}
-
-const treeItems = document.querySelectorAll('#tree-menu li');
-treeItems.forEach(item => {
-  item.addEventListener('click', function (e) {
-    e.stopPropagation();
-    const all = document.querySelectorAll('#tree-menu li');
-    all.forEach(el => {
-      el.classList.remove('expanded', 'selected');
-      el.style.display = 'none';
-      const child = el.querySelector(':scope > ul');
-      if (child) {
-        child.style.display = 'none';
-        child.classList.remove('animating');
-      }
-    });
-    let node = this;
-    while (node && node.matches('#tree-menu li')) {
-      node.style.display = '';
-      node.classList.add('expanded');
-      const child = node.querySelector(':scope > ul');
-      if (child) child.style.display = 'block';
-      node = node.parentElement.closest('li');
-    }
-    const childList = this.querySelector(':scope > ul');
-    if (childList) {
-      childList.querySelectorAll(':scope > li').forEach(li => {
-        li.style.display = 'none';
-        li.classList.remove('show-line');
-      });
-      childList.classList.add('animating');
-      animateTreeChildren(childList);
-    }
-    this.classList.add('selected');
-  });
-});
-

--- a/index.html
+++ b/index.html
@@ -150,21 +150,6 @@
         </div>
       </div>
     </div>
-    <div id="tree-menu">
-      <ul class="tree">
-        <li>루트
-          <ul>
-            <li>가지 1
-              <ul>
-                <li>잎 1-1</li>
-                <li>잎 1-2</li>
-              </ul>
-            </li>
-            <li>가지 2</li>
-          </ul>
-        </li>
-      </ul>
-    </div>
   </div>
   <div id="flash-overlay"></div>
   <script src="game.js"></script>

--- a/style.css
+++ b/style.css
@@ -32,8 +32,43 @@ body {
 .menu ul {
   list-style: none;
   padding-left: 0;
-  margin: 0 0 0 10px;
+  margin: 0 0 0 20px;
   display: none;
+  position: relative;
+  overflow: hidden;
+}
+
+.menu ul::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 1px;
+  height: 0;
+  background-color: #00ff00;
+}
+
+.menu ul.animating::before {
+  animation: drawVertical 0.3s forwards;
+}
+
+.menu ul > li {
+  position: relative;
+  padding: 2px 0;
+}
+
+.menu ul > li::before {
+  content: '';
+  position: absolute;
+  top: 10px;
+  left: -20px;
+  width: 0;
+  border-top: 1px solid #00ff00;
+  transition: width 0.3s;
+}
+
+.menu ul > li.show-line::before {
+  width: 20px;
 }
 
 #action-menus {
@@ -302,78 +337,8 @@ body {
   background-color: #ff0000;
 }
 
-/* Tree menu styling */
-#tree-menu {
-  margin-top: 20px;
-}
-
-.tree,
-.tree ul {
-  list-style: none;
-  margin: 0;
-  padding-left: 20px;
-  position: relative;
-}
-
-.tree li {
-  position: relative;
-  cursor: pointer;
-  padding: 2px 0;
-}
-
-.tree li > ul {
-  display: none;
-  margin-left: 10px;
-  padding-left: 20px;
-  position: relative;
-  overflow: hidden;
-}
-
-.tree li.expanded > ul {
-  display: block;
-}
-
-.tree li > ul::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 1px;
-  height: 0;
-  background-color: #00ff00;
-}
-
-.tree li.expanded > ul::before {
-  height: 100%;
-}
-
-.tree li > ul.animating::before {
-  animation: drawVertical 0.3s forwards;
-}
-
-.tree li > ul > li {
-  position: relative;
-}
-
-.tree li > ul > li::before {
-  content: '';
-  position: absolute;
-  top: 10px;
-  left: -20px;
-  width: 0;
-  border-top: 1px solid #00ff00;
-  transition: width 0.3s;
-}
-
-.tree li > ul > li.show-line::before {
-  width: 20px;
-}
-
 @keyframes drawVertical {
   from { height: 0; }
   to { height: 100%; }
 }
 
-.tree li.selected {
-  color: #ffff00;
-}


### PR DESCRIPTION
## Summary
- animate menu expansions with connecting lines for all submenu displays
- clean up sample tree-menu root element and related code

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a74d2b3234832aaaadf7d64360de93