### PR TITLE
feat: add descriptive log panel

### DIFF
--- a/data/npcs.json
+++ b/data/npcs.json
@@ -2,22 +2,26 @@
   "npcs": {
     "상인": {
       "name": "상인",
+      "description": "다부진 몸매의 상인이 웃으며 손님을 맞이합니다.",
       "stats": { "strength": 1, "perception": 5, "endurance": 2, "charisma": 5, "intelligence": 4, "agility": 2 },
       "xp": 0
     },
     "경비병": {
       "name": "경비병",
+      "description": "단단한 갑옷을 입은 경비병이 경계의 눈빛을 보냅니다.",
       "stats": { "strength": 5, "perception": 4, "endurance": 5, "charisma": 3, "intelligence": 3, "agility": 4 },
       "xp": 40
     },
     "전투용 허수아비": {
       "name": "전투용 허수아비",
+      "description": "전투 연습을 위해 세워진 허수아비입니다.",
       "stats": { "strength": 3, "perception": 2, "endurance": 3, "charisma": 0, "intelligence": 0, "agility": 2 },
       "xp": 20,
       "hostile": true
     },
     "고블린": {
       "name": "고블린",
+      "description": "초록빛 피부의 작은 고블린이 날카로운 이빨을 드러냅니다.",
       "stats": { "strength": 4, "perception": 3, "endurance": 4, "charisma": 1, "intelligence": 1, "agility": 3 },
       "xp": 30,
       "hostile": true

--- a/game.js
+++ b/game.js
@@ -60,6 +60,7 @@ const battleOutcomeEl = document.getElementById('battle-outcome');
 const battleResultCloseEl = document.getElementById('battle-result-close');
 const xpBarEl = document.getElementById('xp-bar');
 const xpTextEl = document.getElementById('xp-text');
+const logEl = document.getElementById('log');
 
 const slotDisplayNames = {
   head: '머리',
@@ -221,9 +222,37 @@ function getTimeSegment() {
   return { key: 'lateNight', name: '심야' };
 }
 
+function addLog(message) {
+  const entry = document.createElement('div');
+  entry.textContent = message;
+  logEl.appendChild(entry);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+function logLocation() {
+  const loc = locations[currentLocation];
+  const seg = getTimeSegment();
+  addLog(`${seg.name} ${String(currentTime).padStart(2, '0')}:00`);
+  if (loc && loc.name) addLog(`장소: ${loc.name}`);
+  const desc = loc && loc.descriptions && loc.descriptions[seg.key]
+    ? loc.descriptions[seg.key]
+    : loc
+    ? loc.description
+    : '';
+  if (desc) addLog(desc);
+}
+
+function logNpcDescription(npc) {
+  const info = npcData[npc];
+  if (info && info.description) {
+    addLog(info.description);
+  }
+}
+
 function advanceTime(hours = 1) {
   currentTime = (currentTime + hours) % 24;
   render();
+  logLocation();
 }
 
 function updateHeaders() {
@@ -806,6 +835,7 @@ function openNpcInteractions(npc, npcIndex) {
   currentNpc = npc;
   updateHeaders();
   highlightItem(npcListEl, npcIndex);
+  logNpcDescription(npc);
   const npcActions = getNpcActions(npc);
   const items = [...npcActions, '뒤로'];
   displayMenu(npcInteractionListEl, items, (idx) => {
@@ -1203,6 +1233,7 @@ async function loadData() {
   currentCategory = categories[0] ? categories[0].key : '';
   render();
   showMainMenu();
+  logLocation();
 }
 
 loadData();

--- a/index.html
+++ b/index.html
@@ -6,7 +6,9 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <div id="game">
+  <div id="ui-container">
+    <div id="log"></div>
+    <div id="game">
     <div id="location">
       <h2 id="location-name"></h2>
       <p id="time-display"></p>
@@ -149,6 +151,7 @@
           <button id="close-status">뒤로</button>
         </div>
       </div>
+    </div>
     </div>
   </div>
   <div id="flash-overlay"></div>

--- a/style.css
+++ b/style.css
@@ -4,9 +4,22 @@ body {
   color: #00ff00;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
   height: 100vh;
   margin: 0;
+}
+
+#ui-container {
+  display: flex;
+  gap: 20px;
+}
+
+#log {
+  width: 300px;
+  height: 600px;
+  border: 2px solid #00ff00;
+  padding: 10px;
+  overflow-y: auto;
 }
 
 #game {


### PR DESCRIPTION
## Summary
- add left-hand log panel for location, time, and NPC descriptions
- log time/location on game load and each hour advance
- show NPC descriptions in log when selecting characters

## Testing
- `node --check game.js`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('data/npcs.json','utf8'));" && echo 'npcs.json valid'`


------
https://chatgpt.com/codex/tasks/task_e_68a7a6cbe278832a9f457070731d630c