### PR TITLE
Add mercenary shop and preservation mechanics

### DIFF
--- a/data/actions.json
+++ b/data/actions.json
@@ -4,6 +4,9 @@
     { "key": "sneak", "name": "잠입", "conditions": [] },
     { "key": "stealth", "name": "은신", "conditions": [] },
     { "key": "lockpick", "name": "자물쇠 해제", "conditions": [] },
-    { "key": "hack", "name": "해킹", "conditions": [] }
+    { "key": "hack", "name": "해킹", "conditions": [] },
+    { "key": "merc_shop", "name": "용병 상점", "conditions": ["at_mercenary_office"] },
+    { "key": "use_injector", "name": "보존제 주입기 사용", "conditions": ["at_office_lounge"] },
+    { "key": "buy_food", "name": "음식 먹기", "conditions": ["at_city_shop"] }
   ]
 }

--- a/data/items.json
+++ b/data/items.json
@@ -39,6 +39,24 @@
       "subtype": "back",
       "conditions": ["guild_access"],
       "properties": {}
+    },
+    "iron_sword": {
+      "name": "철 검",
+      "type": "weapon",
+      "subtype": "melee",
+      "properties": {
+        "strWeight": 80,
+        "multiplier": 1.2,
+        "bonus": 8
+      }
+    },
+    "leather_armor": {
+      "name": "가죽 갑옷",
+      "type": "armor",
+      "subtype": "top",
+      "properties": {
+        "defense": 3
+      }
     }
   }
 }

--- a/data/locations.json
+++ b/data/locations.json
@@ -39,7 +39,7 @@
       },
       "npcs": ["사무원"],
       "connections": ["city", "office_lounge"],
-      "grantConditions": ["guild_access"],
+      "grantConditions": ["guild_access", "at_mercenary_office"],
       "attitudes": {
         "positive": ["guild_access"],
         "neutral": [],
@@ -59,7 +59,7 @@
         "lateNight": "심야의 휴게실에는 거의 사람이 없습니다."
       },
       "connections": ["mercenary_office"],
-      "grantConditions": ["guild_access"],
+      "grantConditions": ["guild_access", "at_office_lounge"],
       "attitudes": {
         "positive": ["guild_access"],
         "neutral": [],
@@ -72,6 +72,7 @@
       "description": "각종 물품을 파는 상점입니다.",
       "npcs": ["상인"],
       "connections": ["city"],
+      "grantConditions": ["at_city_shop"],
       "attitudes": {
         "positive": [],
         "neutral": [],

--- a/index.html
+++ b/index.html
@@ -41,15 +41,27 @@
           </div>
           <span id="hp-text"></span>
         </div>
-        <div class="resource">
-          <span class="resource-label">기력</span>
-          <div class="bar-container">
-            <div id="stamina-bar" class="bar"></div>
+          <div class="resource">
+            <span class="resource-label">기력</span>
+            <div class="bar-container">
+              <div id="stamina-bar" class="bar"></div>
+            </div>
+            <span id="stamina-text"></span>
           </div>
-          <span id="stamina-text"></span>
+          <div class="resource">
+            <span class="resource-label">보존 기간</span>
+            <span id="preservation-text"></span>
+          </div>
+          <div class="resource">
+            <span class="resource-label">활동도</span>
+            <span id="activity-points-text"></span>
+          </div>
+          <div class="resource">
+            <span class="resource-label">원</span>
+            <span id="money-text"></span>
+          </div>
         </div>
-      </div>
-    <div id="battle-ui" style="display:none;">
+      <div id="battle-ui" style="display:none;">
       <div id="battle-log"></div>
       <div id="battle-main">
         <div id="enemy-info">


### PR DESCRIPTION
## Summary
- Track activity points, money, and preservation period as player stats
- Add mercenary weapon/armor shop, preservation injector, and food purchase actions
- Decrease preservation over time and restart game when it expires

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8f40bfbe4832ab6f71505c37ce90b