### PR TITLE
Add skill leveling and hacking minigame

### DIFF
--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -1,0 +1,25 @@
+# Modification Log
+
+This document tracks changes made to the project so far.
+
+## Quest system with corpse harvesting minigame
+- Introduced quest infrastructure with battle and delivery tasks.
+- Added butchering timing minigame to harvest proof items from corpses.
+
+## Debug mode and settings menu
+- Added a global debug flag and helper to print `[DEBUG]` messages.
+- Introduced a settings submenu to toggle debug mode during play.
+
+## Activity rewards for mercenary quests
+- Mercenary office quests now grant activity points instead of money.
+- Created this log to record future modifications.
+
+## Skill experience and hacking minigame
+- Tracked usage-based levels for actions and combat skills (max level 5).
+- Added skill menu to view usage counts and success statistics.
+- Implemented NPC training and study hooks to boost skill progress.
+- Introduced a hacking timing-bar minigame with access/error outcomes.
+
+## Futuristic adversaries
+- Reimagined hostile NPCs with a sci-fi theme, replacing goblins and bandits with rogue drones and neon gang members.
+- Added new enemy types including security robots, synthetic lifeforms, and data pirates, each with unique loot.

--- a/data/items.json
+++ b/data/items.json
@@ -57,6 +57,30 @@
       "properties": {
         "defense": 3
       }
+    },
+    "drone_core": {
+      "name": "드론 코어",
+      "type": "quest"
+    },
+    "bandit_id": {
+      "name": "갱단 신분증",
+      "type": "quest"
+    },
+    "robot_servo": {
+      "name": "보안 서보",
+      "type": "quest"
+    },
+    "synthetic_fiber": {
+      "name": "합성 섬유",
+      "type": "quest"
+    },
+    "data_chip": {
+      "name": "데이터 칩",
+      "type": "quest"
+    },
+    "guild_letter": {
+      "name": "길드 서신",
+      "type": "quest"
     }
   }
 }

--- a/data/locations.json
+++ b/data/locations.json
@@ -83,6 +83,7 @@
     "city_outskirts": {
       "name": "도시 외곽",
       "description": "도시를 벗어나 황야로 이어지는 지역입니다.",
+      "npcs": ["네온 갱단원", "데이터 해적"],
       "connections": ["city", "wilderness"],
       "attitudes": {
         "positive": [],
@@ -93,7 +94,7 @@
     "wilderness": {
       "name": "황야",
       "description": "도시 밖 끝없는 황야입니다.",
-      "npcs": ["고블린"],
+      "npcs": ["불량 드론", "합성 생명체"],
       "connections": ["city_outskirts", "abandoned_factory"],
       "attitudes": {
         "positive": [],
@@ -104,6 +105,7 @@
     "abandoned_factory": {
       "name": "폐공장",
       "description": "오래전 버려진 SF풍의 공장입니다.",
+      "npcs": ["보안 로봇"],
       "connections": ["wilderness"],
       "attitudes": {
         "positive": [],

--- a/data/npcs.json
+++ b/data/npcs.json
@@ -10,13 +10,17 @@
       "name": "사무원",
       "description": "의뢰를 접수하는 사무원입니다.",
       "stats": { "strength": 2, "perception": 4, "endurance": 3, "charisma": 4, "intelligence": 5, "agility": 2 },
-      "xp": 0
+      "xp": 0,
+      "skills": { "hack": 3 },
+      "relationship": 60
     },
     "경비병": {
       "name": "경비병",
       "description": "단단한 갑옷을 입은 경비병이 경계의 눈빛을 보냅니다.",
       "stats": { "strength": 5, "perception": 4, "endurance": 5, "charisma": 3, "intelligence": 3, "agility": 4 },
-      "xp": 40
+      "xp": 40,
+      "skills": { "sneak": 3, "lockpick": 2 },
+      "relationship": 40
     },
     "전투용 허수아비": {
       "name": "전투용 허수아비",
@@ -25,12 +29,45 @@
       "xp": 20,
       "hostile": true
     },
-    "고블린": {
-      "name": "고블린",
-      "description": "초록빛 피부의 작은 고블린이 날카로운 이빨을 드러냅니다.",
-      "stats": { "strength": 4, "perception": 3, "endurance": 4, "charisma": 1, "intelligence": 1, "agility": 3 },
+    "불량 드론": {
+      "name": "불량 드론",
+      "description": "전선이 삐져나온 소형 드론이 위협적으로 깜박입니다.",
+      "stats": { "strength": 4, "perception": 3, "endurance": 4, "charisma": 0, "intelligence": 2, "agility": 3 },
       "xp": 30,
-      "hostile": true
+      "hostile": true,
+      "corpseItem": "drone_core"
+    },
+    "네온 갱단원": {
+      "name": "네온 갱단원",
+      "description": "네온 장식을 두른 범죄자가 주변을 노려봅니다.",
+      "stats": { "strength": 5, "perception": 4, "endurance": 4, "charisma": 2, "intelligence": 2, "agility": 4 },
+      "xp": 35,
+      "hostile": true,
+      "corpseItem": "bandit_id"
+    },
+    "보안 로봇": {
+      "name": "보안 로봇",
+      "description": "폐공장을 순찰하는 무장 보안 로봇이 붉은 센서를 번뜩입니다.",
+      "stats": { "strength": 6, "perception": 5, "endurance": 6, "charisma": 0, "intelligence": 2, "agility": 3 },
+      "xp": 45,
+      "hostile": true,
+      "corpseItem": "robot_servo"
+    },
+    "합성 생명체": {
+      "name": "합성 생명체",
+      "description": "실험실에서 탈출한 미지의 합성 생명체가 낮게 으르렁거립니다.",
+      "stats": { "strength": 4, "perception": 4, "endurance": 5, "charisma": 1, "intelligence": 3, "agility": 4 },
+      "xp": 40,
+      "hostile": true,
+      "corpseItem": "synthetic_fiber"
+    },
+    "데이터 해적": {
+      "name": "데이터 해적",
+      "description": "불법 개조된 사이버덱을 장착한 데이터 해적이 당신을 노립니다.",
+      "stats": { "strength": 3, "perception": 5, "endurance": 3, "charisma": 2, "intelligence": 6, "agility": 4 },
+      "xp": 40,
+      "hostile": true,
+      "corpseItem": "data_chip"
     }
   }
 }

--- a/data/quests.json
+++ b/data/quests.json
@@ -1,0 +1,21 @@
+{
+  "quests": {
+    "rogue_drone_hunt": {
+      "name": "불량 드론 처리",
+      "type": "battle",
+      "giver": "사무원",
+      "target": "불량 드론",
+      "evidenceItem": "drone_core",
+      "count": 1,
+      "reward": {"activity": 100}
+    },
+    "deliver_letter": {
+      "name": "서신 전달",
+      "type": "delivery",
+      "giver": "사무원",
+      "recipient": "상인",
+      "item": "guild_letter",
+      "reward": {"activity": 50}
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -117,6 +117,37 @@
       </div>
       <button id="battle-result-close">확인</button>
     </div>
+    <div id="quest-ui" style="display:none;">
+      <h3>의뢰</h3>
+      <ul id="quest-list"></ul>
+      <button id="close-quest">뒤로</button>
+    </div>
+    <div id="skills-ui" style="display:none;">
+      <h3>기술</h3>
+      <ul id="skill-list"></ul>
+      <button id="close-skills">뒤로</button>
+    </div>
+    <div id="butchering-ui" style="display:none;">
+      <h3>사체 손질</h3>
+      <div id="butcher-bar">
+        <div class="zone success"></div>
+        <div class="zone big"></div>
+        <div id="butcher-arrow"></div>
+      </div>
+      <p id="butcher-instruction">스페이스바로 정지</p>
+      <p id="butcher-result"></p>
+    </div>
+    <div id="hacking-ui" style="display:none;">
+      <pre id="hacking-code"></pre>
+      <div id="hacking-bar">
+        <div id="hacking-gauge"></div>
+        <div class="zone">
+          <div class="big"></div>
+        </div>
+      </div>
+      <p id="hacking-timer"></p>
+      <p id="hacking-result"></p>
+    </div>
     <div id="player-input-container">
       <input type="text" id="player-command" placeholder="명령을 입력하세요" />
       <button id="submit-command">입력</button>

--- a/style.css
+++ b/style.css
@@ -199,6 +199,42 @@ body {
   cursor: pointer;
 }
 
+#quest-ui {
+  text-align: center;
+}
+
+#butcher-bar {
+  position: relative;
+  width: 300px;
+  height: 20px;
+  border: 1px solid #00ff00;
+  margin: 10px auto;
+}
+
+#butcher-bar .zone.success {
+  position: absolute;
+  left: 30%;
+  width: 40%;
+  height: 100%;
+  background: #003300;
+}
+
+#butcher-bar .zone.big {
+  position: absolute;
+  left: 45%;
+  width: 10%;
+  height: 100%;
+  background: #006600;
+}
+
+#butcher-arrow {
+  position: absolute;
+  top: -5px;
+  width: 2px;
+  height: 30px;
+  background: #ffff00;
+}
+
 #status-ui {
   display: none;
   margin-top: 20px;
@@ -369,5 +405,70 @@ body {
   color: #00ff00;
   border: 1px solid #00ff00;
   cursor: pointer;
+}
+
+#skills-ui {
+  display: none;
+  margin-top: 20px;
+}
+#skills-ui ul {
+  list-style: none;
+  padding-left: 0;
+}
+#skills-ui button {
+  margin-top: 10px;
+  background-color: #000;
+  color: #00ff00;
+  border: 1px solid #00ff00;
+  cursor: pointer;
+}
+
+#hacking-ui {
+  display: none;
+  margin-top: 20px;
+}
+#hacking-code {
+  height: 150px;
+  border: 1px solid #00ff00;
+  padding: 5px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+#hacking-bar {
+  position: relative;
+  width: 100%;
+  height: 20px;
+  border: 1px solid #00ff00;
+  margin-bottom: 5px;
+}
+#hacking-gauge {
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 0;
+  background-color: #00ff00;
+}
+#hacking-bar .zone {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  left: 60%;
+  width: 20%;
+  background-color: rgba(255, 255, 0, 0.2);
+}
+#hacking-bar .zone .big {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  left: 25%;
+  width: 50%;
+  background-color: rgba(0, 255, 255, 0.4);
+}
+#hacking-result {
+  margin-top: 5px;
+}
+#hacking-code.error {
+  color: #ff0000;
 }
 


### PR DESCRIPTION
## Summary
- Track action and skill usage with levels up to 5 and show stats in a new skills menu
- Allow friendly NPCs to train the player’s techniques for faster progress
- Add a hacking minigame with a decaying gauge, timer, and Access/Error outcomes
- Populate the world with sci-fi enemies like rogue drones, neon gang members, and security robots

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be0b985670832a946a9aa76f04784a